### PR TITLE
RFC & Required Changes

### DIFF
--- a/.bolt.yml
+++ b/.bolt.yml
@@ -1,8 +1,8 @@
 paths:
-    cache: app/cache
-    config: app/config
-    database: app/database
-    web: public
-    themebase: public/theme
-    files: public/files
-    view: public/bolt-public/view
+    cache: %app%/cache
+    config: %app%/config
+    database: %app%/database
+    web: %site%/public
+    themebase: %web%/theme
+    files: %web%/files
+    view: %web%/bolt-public

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -23,6 +23,7 @@ theme:
 # The locale that'll be used by the application. If no locale is set the
 # fallback locale is 'en_GB'. For available options, see:
 # https://docs.bolt.cm/other/locales
+
 #
 # In some cases it may be needed to specify (non-standard) variations of the
 # locale to get everything to work as desired.
@@ -30,7 +31,10 @@ theme:
 # This can be done as [nl_NL, Dutch_Netherlands] when specifying multiple
 # locales, ensure the first is a standard locale.
 locale: en_GB
-#timezone: UTC
+
+# Set the timezone to be used on the website. For a list of valid timezone
+# settings, see: http://php.net/manual/en/timezones.php
+# timezone: UTC
 
 # Set maintenance mode on or off.
 #
@@ -203,8 +207,8 @@ thumbnails:
     default_image: [ 1000, 750 ]
     quality: 80
     cropping: crop
-    notfound_image: view/img/default_notfound.png
-    error_image: view/img/default_error.png
+    notfound_image: bolt_assets://img/default_notfound.png
+    error_image: bolt_assets://img/default_error.png
     save_files: false
     allow_upscale: false
     exif_orientation: true
@@ -216,7 +220,7 @@ thumbnails:
 # left in the content that is shown to users. For example, tags like `<script>`
 # or `onclick`-attributes.
 htmlcleaner:
-    allowed_tags: [ div, span, p, br, hr, s, u, strong, em, i, b, li, ul, ol, mark, blockquote, pre, code, tt, h1, h2, h3, h4, h5, h6, dd, dl, dh, table, tbody, thead, tfoot, th, td, tr, a, img, address, abbr, iframe, caption ]
+    allowed_tags: [ div, span, p, br, hr, s, u, strong, em, i, b, li, ul, ol, mark, blockquote, pre, code, tt, h1, h2, h3, h4, h5, h6, dd, dl, dh, table, tbody, thead, tfoot, th, td, tr, a, img, address, abbr, iframe, caption, sub, super ]
     allowed_attributes: [ id, class, style, name, value, href, src, alt, title, width, height, frameborder, allowfullscreen, scrolling, target, colspan, rowspan ]
 
 # Uploaded file handling
@@ -265,6 +269,7 @@ debug_permission_audit_mode: false
 # debug_error_level: 8181           # equivalent to E_ALL &~ E_NOTICE &~ E_DEPRECATED &~ E_USER_DEPRECATED &~ E_WARNING
 debug_error_level: -1               # equivalent to E_ALL
 debug_error_use_symfony: false      # When set to true, Symfony Profiler will be used for exception display when possible
+debug_trace_argument_limit: 4       # Determine how many steps in the backtrace will show (dump) arguments.
 
 # error level when debug is disabled
 #production_error_level: 8181 # = E_ALL &~ E_NOTICE &~ E_WARNING &~ E_DEPRECATED &~ E_USER_DEPRECATED
@@ -328,8 +333,8 @@ liveeditor: false
 # it, your mail might disappear into a black hole, without producing any errors.
 # Generally speaking, using 'smtp' is the better option, so use that if possible.
 #
-# Protip: If your webhost does not support SMTP, sign up for a (free) Sendgrid
-# account at https://sendgrid.com/free for sending emails reliably.
+# Protip: If your webhost does not support SMTP, sign up for a (free) Sparkpost
+# account at https://www.sparkpost.com/pricing/ for sending emails reliably.
 
 # mailoptions:
 #     transport: smtp
@@ -404,12 +409,12 @@ hash_strength: 10
 #         prefer-stable: true            # Prefer stable releases over development ones
 #         prefer-dist: true              # Forces installation from package dist even for dev versions.
 #         prefer-source: false           # Forces installation from package sources when possible, including VCS information.
-#         optimize-autoloader: false     # Optimize autoloader during autoloader dump.
-#         classmap-authoritative: false  # Autoload classes from the classmap only. Implicitly enables `optimize-autoloader`.
+#         config:
+#             optimize-autoloader: false     # Optimize autoloader during autoloader dump.
+#             classmap-authoritative: false  # Autoload classes from the classmap only. Implicitly enables `optimize-autoloader`.
 
-# Enforcing the use of SSL. If set, all but the front-end pages will enforce an
-# SSL connection (and redirect to HTTPS if you attempt to visit the backend over
-# plain HTTP).
+# Enforcing the use of SSL. If set, all pages will enforce an SSL connection,
+# and redirect to HTTPS if you attempt to visit plain HTTP pages.
 # enforce_ssl: true
 
 # If configured, Bolt will trust X-Forwarded-XXX headers from the listed IP
@@ -449,3 +454,12 @@ hash_strength: 10
 #        disable: true     # Disable news panel. Defaults to false. "Alerts" will still be shown.
 #    stack:
 #        disable: true     # Disable stack usage. Defaults to false.
+
+# Options that will be forced in next major version
+compatibility:
+    # Whether to return TemplateView instead of TemplateResponse from Controller\Base::render()
+    # Response methods cannot be used on TemplateView objects.
+    # Setting this value to false is deprecated.
+    template_view: true
+    # Set to 'false' to enable using a newer version of the setcontent parser.
+    setcontent_legacy: true

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,5 @@
             "Bolt\\Composer\\ScriptHandler::installThemesAndFiles",
             "nut extensions:setup"
         ]
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-release/3.2" : "3.2.x-dev"
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
             "Bolt\\Composer\\ScriptHandler::installAssets"
         ],
         "post-update-cmd": [
+            "Bolt\\Composer\\ScriptHandler::updateProject",
             "Bolt\\Composer\\ScriptHandler::installAssets"
         ],
         "post-create-project-cmd": [

--- a/extensions/composer.json
+++ b/extensions/composer.json
@@ -18,7 +18,7 @@
     "name": "bolt/extensions",
     "prefer-stable": true,
     "provide": {
-        "bolt/bolt": "3.2.6"
+        "bolt/bolt": "3.3.0"
     },
     "repositories": {
         "packagist": false,


### PR DESCRIPTION
OK, so:

### `.bolt.yml`

These will bite you if you omit them.

The defaults are **not** needed in 3.3.0+ but it makes sense to have them there in this use case as you'd probably want them to be (somewhat) customisable.

Composer will remove any defaults on update, but that will occur in this case post-clone and the developer has time to reference/change.

### `app/config/config.yml`

Changes here should be pretty obvious, and I have included one of the values from 3.4 as it is a good to have early.

However some red flags:
 - `debug_show_loggedoff: true` will get sites hacked. Trust me that people do *not* check this setting
 - `debug_error_use_symfony: false` is probably better being set to `true`. Bolt's exception handler is "pretty" and all, but it is slow, only returns the first exception, and drops the first line of the trace … can you tell I am still not happy with what was done there :wink: 
 - `caching/config: false` & `caching/templates: false` is generally a bad idea. Both of those are last resort `false` settings. 99 times out of 100 setting the `php.ini` setting `opcache.validate_timestamps`  to `1` and increasing the value of `opcache.max_accelerated_files` is the reason people his problems with either of those. Bolt (and Twig) check the time stamp on the cached files and will invalidate if the "source" is newer

### `composer.json`

The `branch-alias` confuses everyone, probably better to drop it as it really makes no sense in the context of what you're doing here.

### `extensions/composer.json`

Bolt 3.2.6 is kinda old :wink: 
